### PR TITLE
Add instrumentation and exception logging

### DIFF
--- a/lib/rails_twirp.rb
+++ b/lib/rails_twirp.rb
@@ -4,6 +4,7 @@ require "rails_twirp/application"
 require "rails_twirp/base"
 require "rails_twirp/route_set"
 require "rails_twirp/testing/integration_test"
+require "rails_twirp/log_subscriber"
 
 module RailsTwirp
   mattr_accessor :test_app

--- a/lib/rails_twirp/base.rb
+++ b/lib/rails_twirp/base.rb
@@ -11,6 +11,7 @@ require "action_controller/metal/helpers"
 require "rails_twirp/rescue"
 require "rails_twirp/url_for"
 require "rails_twirp/implicit_render"
+require "rails_twirp/instrumentation"
 
 module RailsTwirp
   class Base < AbstractController::Base
@@ -25,7 +26,6 @@ module RailsTwirp
     include UrlFor
     include AbstractController::AssetPaths
     include AbstractController::Caching
-    include AbstractController::Logger
 
     include ActionView::Rendering
     include RenderPb
@@ -35,6 +35,7 @@ module RailsTwirp
     # These need to be last so errors can be handled as early as possible.
     include AbstractController::Callbacks
     include Rescue
+    include Instrumentation
 
     attr_internal :request, :env, :response_class
     def initialize

--- a/lib/rails_twirp/instrumentation.rb
+++ b/lib/rails_twirp/instrumentation.rb
@@ -1,0 +1,32 @@
+module RailsTwirp
+  module Instrumentation
+    extend ActiveSupport::Concern
+
+    include AbstractController::Logger
+
+    def process_action(*)
+      raw_payload = {
+        controller: self.class.name,
+        action: action_name,
+        request: request,
+        http_request: http_request,
+        headers: http_request.headers,
+        path: http_request.fullpath
+      }
+
+      ActiveSupport::Notifications.instrument("start_processing.rails_twirp", raw_payload)
+
+      ActiveSupport::Notifications.instrument("process_action.rails_twirp", raw_payload) do |payload|
+        result = super
+        if response_body.is_a?(Twirp::Error)
+          payload[:code] = response_body.code
+          payload[:msg] = response_body.msg
+        else
+          payload[:code] = :success
+        end
+        payload[:response] = response_body
+        result
+      end
+    end
+  end
+end

--- a/lib/rails_twirp/log_subscriber.rb
+++ b/lib/rails_twirp/log_subscriber.rb
@@ -1,0 +1,64 @@
+require "active_support/log_subscriber"
+
+module RailsTwirp
+  class LogSubscriber < ActiveSupport::LogSubscriber
+    def start_processing(event)
+      return unless logger.info?
+
+      payload = event.payload
+
+      info "Processing by #{payload[:controller]}##{payload[:action]}"
+    end
+
+    def process_action(event)
+      payload = event.payload
+      exception_raised(payload[:http_request], payload[:exception_object]) if payload[:exception_object]
+
+      info do
+        code = payload.fetch(:code, :internal)
+
+        message = +"Completed #{code} in #{event.duration.round}ms (Allocations: #{event.allocations})"
+        message << "\n\n" if defined?(Rails.env) && Rails.env.development?
+
+        message
+      end
+    end
+
+    private
+
+    def exception_raised(request, exception)
+      backtrace_cleaner = request.get_header("action_dispatch.backtrace_cleaner")
+      wrapper = ActionDispatch::ExceptionWrapper.new(backtrace_cleaner, exception)
+
+      log_error(wrapper)
+    end
+
+    def log_error(wrapper)
+      exception = wrapper.exception
+      trace = wrapper.exception_trace
+
+      message = []
+      message << "  "
+      message << "#{exception.class} (#{exception.message}):"
+      message.concat(exception.annotated_source_code) if exception.respond_to?(:annotated_source_code)
+      message << "  "
+      message.concat(trace)
+
+      log_array(message)
+    end
+
+    def log_array(array)
+      lines = Array(array)
+
+      return if lines.empty?
+
+      if logger.formatter&.respond_to?(:tags_text)
+        fatal { lines.join("\n#{logger.formatter.tags_text}") }
+      else
+        fatal { lines.join("\n") }
+      end
+    end
+  end
+end
+
+RailsTwirp::LogSubscriber.attach_to :rails_twirp

--- a/lib/rails_twirp/testing/integration_test.rb
+++ b/lib/rails_twirp/testing/integration_test.rb
@@ -5,6 +5,7 @@ module RailsTwirp
     Response = Struct.new(:status, :body, :headers)
 
     attr_reader :response, :request, :controller
+    attr_writer :mount_path
 
     def initialize(name)
       super
@@ -20,10 +21,6 @@ module RailsTwirp
 
     def before_rpc(&block)
       @before_rpc << block
-    end
-
-    def mount_path(path)
-      @mount_path = path
     end
 
     def rpc(svc, rpc, request, headers: nil)


### PR DESCRIPTION
This PR adds instrumentation and exception logging, so we get more insight into what is actually happening during requests.

I also modified IntegrationTest to call into app, instead of the service directly. This makes sure the whole middleware stack is called, including any Rails middlewares that exist. This makes it closer to a real request.