### PR TITLE
Include Twirp::Error message in log

### DIFF
--- a/lib/rails_twirp/log_subscriber.rb
+++ b/lib/rails_twirp/log_subscriber.rb
@@ -17,7 +17,9 @@ module RailsTwirp
       info do
         code = payload.fetch(:code, :internal)
 
-        message = +"Completed #{code} in #{event.duration.round}ms (Allocations: #{event.allocations})"
+        message = +"Completed #{code}"
+        message << ": #{payload[:msg]}" if payload[:msg]
+        message << " in #{event.duration.round}ms (Allocations: #{event.allocations})"
         message << "\n\n" if defined?(Rails.env) && Rails.env.development?
 
         message


### PR DESCRIPTION
Right now just the error code is logged, but we should also log the error message

Closes #10 