### PR TITLE
bouke's fix to wrong protobuf version being installed for apple chips

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,21 @@ Or install it yourself as:
 $ gem install rails_twirp
 ```
 
+## Installing correct protobuf version for M1 Mac Chips
+
+If you run into an issue with protobuf universal-darwin version, please paste this in your Gemfile as recommended by @bouke :
+
+```ruby
+# HACK(bouk): Overwrite Bundler's platform matcher to ignore universal CPU
+# The protobuf and gRPC 'universal' macOS gems break on M1
+module Bundler::MatchPlatform
+  def match_platform(p)
+    return false if ::Gem::Platform === platform && platform.cpu == "universal"
+    Bundler::MatchPlatform.platforms_match?(platform, p)
+  end
+end
+```
+
 ## Contributing
 Contribution directions go here.
 


### PR DESCRIPTION
Document how to overwrite Bundler's platform matcher to ignore `universal` CPU platforms as the protobuf and gRPC 'universal' macOS gems break on M1.