### PR TITLE
Allow user-defined exception handling

### DIFF
--- a/lib/rails_twirp.rb
+++ b/lib/rails_twirp.rb
@@ -8,6 +8,7 @@ require "rails_twirp/log_subscriber"
 
 module RailsTwirp
   mattr_accessor :test_app
+  mattr_accessor :unhandled_exception_handler
 end
 
 require "rails_twirp/engine" if defined?(Rails)

--- a/lib/rails_twirp/exception_handling.rb
+++ b/lib/rails_twirp/exception_handling.rb
@@ -9,17 +9,27 @@ module RailsTwirp
     def process_action(*)
       super
     rescue Exception => e
+      # Only the exceptions which are not captured by ActionController-like "rescue_from" end up here.
+      # The idea is that any exception which is rescued by the controller is treated as part of the business
+      # logic, and thus taking action on it is the responsibility of the controller which uses "rescue_from".
+      # If an exception ends up here it means it wasn't captured by the handlers defined in the controller.
+
       # We adopt the same error handling logic as Rails' standard middlewares:
       # 1. When we 'show exceptions' we make the exception bubble up—this is useful for testing
+      #    If the exception gets raised here error reporting will happen in the middleware of the APM package
+      #    higher in the call stack.
       raise e unless http_request.show_exceptions?
 
-      # 2. When we want to show detailed exceptions we include the exception message in the error
+      # 2. We report the error to the error tracking service, this needs to be configured.
+      RailsTwirp.unhandled_exception_handler&.call(e)
+
+      # 3. When we want to show detailed exceptions we include the exception message in the error
       if http_request.get_header("action_dispatch.show_detailed_exceptions")
         self.response_body = Twirp::Error.internal_with(e)
         return
       end
 
-      # 3. Otherwise we just return a vague internal error message
+      # 4. Otherwise we just return a vague internal error message
       self.response_body = Twirp::Error.internal("Internal error")
     end
   end


### PR DESCRIPTION
To integrate tools like Scout APM, AppSignal, Sentry etc. we need to be able to capture exceptions before converting them to a Twirp error. We add an extra configuration parameter which accepts a Proc, this proc will receive any exception which did not get rescued by the controller rescue_from and did not get re-raised "up the stack". We will assume that if an exception gets re-raised it should be handled by the error handling middleware that APM solutions tend to implement.