### PR TITLE
Fix decode_rack_response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### 0.15.0
 
+* Exclude versions of Rails 7 which were incompatible with the pbbuilder ActionView handler, as pbbuilder cannot work there at all
 * Fix decode_rack_response to be compatible with Rack response body wrappers (and conform to the Rack SPEC)
 
 ### 0.14.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 0.15.0
+
+* Fix decode_rack_response to be compatible with Rack response body wrappers (and conform to the Rack SPEC)
+
 ### 0.14.0
 * Adding frozen_string_literal: true to all files.
 

--- a/lib/rails_twirp/testing/integration_test.rb
+++ b/lib/rails_twirp/testing/integration_test.rb
@@ -91,7 +91,7 @@ module RailsTwirp
     end
 
     def decode_rack_response(service, rpc, status, headers, body)
-      body = body.join # body is an Enumerable
+      body = Array.wrap(body).join # body is each-able
 
       if status === 200
         output_class = service.rpcs[rpc][:output_class]

--- a/lib/rails_twirp/version.rb
+++ b/lib/rails_twirp/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RailsTwirp
-  VERSION = "0.14"
+  VERSION = "0.15"
 end


### PR DESCRIPTION
The Rack response body is _not_ an Enumerable, it just responds to #each. The method was assuming otherwise, which led to breakage when trying to use https://github.com/appsignal/appsignal-ruby/pull/1037