### PR TITLE
loose rails dependency, so it would be possible to use >7.1.4

### DIFF
--- a/rails_twirp.gemspec
+++ b/rails_twirp.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   # Rails has shipped an incompatible change in ActiveView, that was reverted in later versions
   # but at this time has not been released as a 7.x version
   # @see https://github.com/rails/rails/pull/51023
-  spec.add_runtime_dependency "rails", ">= 6.1.3", " <= 7.1.3"
+  spec.add_runtime_dependency "rails", ">= 6.1.3", " < 7.1.4"
   spec.add_runtime_dependency "twirp", ">= 1.9", "< 1.11"
   spec.required_ruby_version = ">= 3"
 end


### PR DESCRIPTION
We expect that rails would release changes in 7.1.4 version that are important for this gem to work. But our gemspec requirements don't allow this version to be used.

Goal of this pull request is to loosen our dependency requirements to allow version 7.1.4 and up to be used.